### PR TITLE
Add pulse finding framework

### DIFF
--- a/include/PulseFinding.hpp
+++ b/include/PulseFinding.hpp
@@ -1,0 +1,18 @@
+#ifndef __PULSEFINDING__
+#define __PULSEFINDING__
+
+#include "TH1D.h"
+#include "WaveformFitResult.hpp"
+
+// Find pulses in a given waveform
+// arguments:
+// int algo_type : which pulse finding algorithm to use?
+// TH1D *hwaveform : the input waveform
+// WaveformFitResult *fitresult : store the list of pulses in WaveformFitResult
+void find_pulses(int algo_type, TH1D *hwaveform, WaveformFitResult *fitresult );
+
+// Do simple comparison to fixed threshold to find pulses
+void simple_threshold_technique(TH1D *hwaveform, WaveformFitResult *fitresult );
+
+#endif // __PULSEFINDING__
+

--- a/ptf_timing_analysis.cpp
+++ b/ptf_timing_analysis.cpp
@@ -25,6 +25,7 @@
 #include <vector>
 #include <algorithm>
 #include <string>
+#include <iomanip>
 
 using namespace std;
 

--- a/src/PTFAnalysis.cpp
+++ b/src/PTFAnalysis.cpp
@@ -2,6 +2,7 @@
 #include "Configuration.hpp"
 #include "Utilities.hpp"
 #include "TVirtualFFT.h"
+#include "PulseFinding.hpp"
 
 #include "TH2D.h"
 
@@ -294,6 +295,7 @@ PTFAnalysis::PTFAnalysis( TFile* outfile, PTF::Wrapper & wrapper, double errorba
   bool terminal_output;
   bool pulse_location_cut;
   bool fft_cut;
+  bool do_pulse_finding;
 
   config.Load(config_file);
   if( !config.Get("terminal_output", terminal_output) ){
@@ -307,6 +309,10 @@ PTFAnalysis::PTFAnalysis( TFile* outfile, PTF::Wrapper & wrapper, double errorba
   if( !config.Get("fft_cut", fft_cut) ){
     cout << "Missing fft_cut parameter from config file." << endl;
     exit( EXIT_FAILURE );
+  }
+  if( !config.Get("do_pulse_finding", do_pulse_finding) ){
+    cout << "Disabling pulse finding." << std::endl;
+    do_pulse_finding = false;
   }
 
   static int instance_count =0;
@@ -379,8 +385,17 @@ PTFAnalysis::PTFAnalysis( TFile* outfile, PTF::Wrapper & wrapper, double errorba
 	    hwaveform->SetBinError( ibin, errorbar );
       }
       InitializeFitResult( j, numWaveforms );
+      
+      // Do pulse finding (if requested)
+      if(do_pulse_finding){
+        find_pulses(0, hwaveform, fitresult);
+      }else{
+        fitresult->numPulses = 0;
+      }
+        
       // Do simple charge sum calculation
       if( channel.pmt == 0 ) ChargeSum(8135.4);
+
       // For main PMT do FFT and check if there is a waveform
       // If a waveform present then fit it
       bool dofit = true;

--- a/src/PulseFinding.cpp
+++ b/src/PulseFinding.cpp
@@ -1,0 +1,61 @@
+#include "PulseFinding.hpp"
+#include <iostream>
+
+void find_pulses(int algo_type, TH1D *hwaveform, WaveformFitResult *fitresult ){
+
+  // Reset the number of pulses
+  fitresult->numPulses = 0;
+
+  if(algo_type == 0){
+    simple_threshold_technique(hwaveform, fitresult);
+  }else{
+    std::cerr << "Invalid pulse finding algorithm = " << algo_type
+              << ". Exiting"<< std::endl;
+    exit(0);
+  }
+  
+  
+}
+
+
+
+void simple_threshold_technique(TH1D *hwaveform, WaveformFitResult *fitresult ){
+  
+  // Loop over waveform; look for every case of waveform going below fixed threshold
+  int threshold = 2045 - 15;
+
+  int nsamples = hwaveform->GetNbinsX();
+
+  int min_bin = 9999, min_value = 9999; // Find the minimum bin and value for each pulse.
+  bool in_pulse = false; // are we currently in a pulse?
+  for(int ib = 1; ib < nsamples+1; ib++){
+    int sample = hwaveform->GetBinContent(ib);
+
+    if(sample < min_value){
+      min_value = sample;
+      min_bin = ib;
+    }
+    
+    if(sample < threshold && !in_pulse){ // found a pulse
+      in_pulse = true;      
+    }
+    
+    if(sample >= threshold && in_pulse){ /// finished this pulse
+      in_pulse = false;
+      if(fitresult->numPulses < MAX_PULSES){
+        fitresult->pulseTimes[fitresult->numPulses] = min_bin * 8.0;
+        fitresult->pulseCharges[fitresult->numPulses] = min_value;        
+        if(0)std::cout << "Pulse found : " << fitresult->numPulses << " " << min_bin
+                  << " " << min_value << " " << std::endl;
+        fitresult->numPulses++;      
+      }
+      min_bin = 9999, min_value = 9999;
+    }
+    
+  }
+
+  if(fitresult->numPulses){ std::cout << "number of pulses found: " << fitresult->numPulses << " " << std::endl;}
+  
+}
+
+


### PR DESCRIPTION
Adding a framework for doing pulse fitting.  I implement the pulse fitting in a separate file PulseFinding.[hpp,cpp].  The pulse finding has hooks for doing different types of pulse finding; for the moment implement a simple pulse finding based on threshold.

The pulse finding gets used in PTFAnalysis.  It gets runs first, so results can be used in fitting.  The pulse finding can be enabled by a parameter in the config file (disabled by default).

This PR build on PR#4, using the changes to WaveformFitResult to save the pulses I find.