### PR TITLE
Integrate mPMT framework with Wrapper class

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,24 +102,38 @@ Here is a brief overview of the data types you'll use (all in "wrapper.hpp", in 
 
 ```c++
 enum Gantry {
-  Gantry0,
-  Gantry1
+  Gantry0 = 0,
+  Gantry1 = 1
 };
 ```
 
 Just an enum for which gantry you want to reference.
 
-
-### PMT Channel (`struct PMTChannel`)
+### PMTType (`enum PMTType`)
 
 ```c++
-typedef struct PMTChannel {
+enum PMTType {
+  Hamamatsu_R3600_PMT = 0,
+  PTF_Monitor_PMT = 1,
+  PTF_Receiver_PMT = 2,
+  Hamamatsu_R12199_PMT = 3
+};
+```
+
+An enum for the PMT type
+
+
+### PMT (`struct PMT`)
+
+```c++
+typedef struct PMT {
   int pmt;
   int channel;
+  PMTType type;
 } PMTChannel;
 ```
 
-Represents a pair used to map PMTs to their channel. `int pmt` is the PMT's number, and `int channel` is the channel used to read the info.
+A structure which maps PMTs to their channel and type. `int pmt` is the PMT's number, `int channel` is the digitizer channel used to read the info, and `PMTType type` is the type of PMT.
 
 
 ### Phidget Reading (`struct PhidgetReading`)
@@ -155,9 +169,9 @@ Contains the position information for a gantry.
 
 Here are the methods of `PTF::Wrapper`:
 
-- `Wrapper(size_t maxSamples, size_t sampleSize, const std::vector<PMTChannel>& activeChannels, const std::vector<int>& phidgets, const std::vector<Gantry>& gantries)`
-    - Constructs a wrapper object and prepares to read the given channels and phidgets.
-- `Wrapper(size_t maxSamples, size_t sampleSize, const std::vector<PMTChannel>& activeChannels, const std::vector<int>& phidgets, const std::vector<Gantry>& gantries, const std::string& fileName, const std::string& treeName = "scan_tree")`
+- `Wrapper(size_t maxSamples, size_t sampleSize, const std::vector<PMT>& activePMTs, const std::vector<int>& phidgets, const std::vector<Gantry>& gantries)`
+    - Constructs a wrapper object and prepares to read the given PMTs and phidgets.
+- `Wrapper(size_t maxSamples, size_t sampleSize, const std::vector<PMT>& activePMTs, const std::vector<int>& phidgets, const std::vector<Gantry>& gantries, const std::string& fileName, const std::string& treeName = "scan_tree")`
     - Constructs a wrapper object like above, but immediately opens a file and loads a scan tree ("scan_tree" by default).
 - `void openFile(const std::string& fileName, const std::string& treeName = "scan_tree")`
     - Opens a file, as described above.

--- a/README.md
+++ b/README.md
@@ -121,8 +121,8 @@ enum PMTType {
   Hamamatsu_R3600_PMT = 0,
   PTF_Monitor_PMT = 1,
   PTF_Receiver_PMT = 2,
-  Hamamatsu_R12199_PMT = 3,
-  mPMT_Monitor_PMT
+  mPMT_REV0_PMT = 3,
+  mPMT_Monitor_PMT = 4
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -135,16 +135,16 @@ typedef struct PhidgetReading {
 Data read for the phidget. Mostly you'll probably just want index 0 of each, which is the magnetic field.
 
 
-### Ganty Position (`struct GantryPos`)
+### Ganty Position (`struct GantryData`)
 
 ```c++
-typedef struct GantryPos {
+typedef struct GantryData {
   double x;
   double y;
   double z;
   double theta;
   double phi;
-} GantryPos;
+} GantryData;
 ```
 
 Contains the position information for a gantry.
@@ -155,9 +155,9 @@ Contains the position information for a gantry.
 
 Here are the methods of `PTF::Wrapper`:
 
-- `Wrapper(size_t maxSamples, size_t sampleSize, const std::vector<PMTChannel>& activeChannels, const std::vector<int>& phidgets)`
+- `Wrapper(size_t maxSamples, size_t sampleSize, const std::vector<PMTChannel>& activeChannels, const std::vector<int>& phidgets, const std::vector<Gantry>& gantries)`
     - Constructs a wrapper object and prepares to read the given channels and phidgets.
-- `Wrapper(size_t maxSamples, size_t sampleSize, const std::vector<PMTChannel>& activeChannels, const std::vector<int>& phidgets, const std::string& fileName, const std::string& treeName = "scan_tree")`
+- `Wrapper(size_t maxSamples, size_t sampleSize, const std::vector<PMTChannel>& activeChannels, const std::vector<int>& phidgets, const std::vector<Gantry>& gantries, const std::string& fileName, const std::string& treeName = "scan_tree")`
     - Constructs a wrapper object like above, but immediately opens a file and loads a scan tree ("scan_tree" by default).
 - `void openFile(const std::string& fileName, const std::string& treeName = "scan_tree")`
     - Opens a file, as described above.
@@ -181,7 +181,7 @@ Here are the methods of `PTF::Wrapper`:
     - Returns a pointer to an array of length `sampleSize` which is the sample for the PMT on the current entry. Throws `SampleOutOfRange` if the sample is too large, `InvalidPMT` if the PMT can't be found and `NoFileIsOpen` if no file is open.
 - `int getSampleLength() const`
     - Returns `sampleSize`.
-- `GantryPos getDataForCurrentEntry(Gantry whichGantry) const`
+- `GantryData getDataForCurrentEntry(Gantry whichGantry) const`
     - Gets gantry position info for a given gantry. Throws if no file is open.
 - `PhidgetReading getReadingFOrPhidget(int phidget) const`
     - Gets the phidget data for the given phidget and current entry. Throws `InvalidPhidget` if the phidget wasn't registered, and `NoFileIsOpen` if no file is open.

--- a/README.md
+++ b/README.md
@@ -121,7 +121,8 @@ enum PMTType {
   Hamamatsu_R3600_PMT = 0,
   PTF_Monitor_PMT = 1,
   PTF_Receiver_PMT = 2,
-  Hamamatsu_R12199_PMT = 3
+  Hamamatsu_R12199_PMT = 3,
+  mPMT_Monitor_PMT
 };
 ```
 

--- a/field_to_csv.cpp
+++ b/field_to_csv.cpp
@@ -30,7 +30,10 @@ int main(int argc, char** argv) {
   //   {6, 9},
   //   {7, 10}
   // };
-  PTF::Wrapper wrapper = PTF::Wrapper(16384, 70, activeChannels, phidgets);
+
+  vector<PTF::Gantry> gantries = {PTF::Gantry0, PTF::Gantry1};
+
+  PTF::Wrapper wrapper = PTF::Wrapper(16384, 70, activeChannels, phidgets, gantries);
 
   unordered_set<int> skipLines = {};// {962,1923,2884,5240,6201,9611,10572,11533,12494,13455,15811,16771};
 

--- a/field_to_csv.cpp
+++ b/field_to_csv.cpp
@@ -20,20 +20,11 @@ int main(int argc, char** argv) {
   string csv_f  = "/neut/datasrv2a/jmgwalker/ptf/ptf-analysis-2/develop/ptf-analysis-2/field_to_csv/out_run0" + run_no + ".csv";
 
   vector<int> phidgets = {0, 1, 3, 4};
-  vector<PTF::PMTChannel> activeChannels = {};
-  //   {0, 3},
-  //   {1, 4},
-  //   {2, 5},
-  //   {3, 6},
-  //   {4, 7}, 
-  //   {5, 8},
-  //   {6, 9},
-  //   {7, 10}
-  // };
+  vector<PTF::PMT> activePMTs = {};
 
   vector<PTF::Gantry> gantries = {PTF::Gantry0, PTF::Gantry1};
 
-  PTF::Wrapper wrapper = PTF::Wrapper(16384, 70, activeChannels, phidgets, gantries);
+  PTF::Wrapper wrapper = PTF::Wrapper(16384, 70, activePMTs, phidgets, gantries);
 
   unordered_set<int> skipLines = {};// {962,1923,2884,5240,6201,9611,10572,11533,12494,13455,15811,16771};
 

--- a/include/ErrorBarAnalysis.hpp
+++ b/include/ErrorBarAnalysis.hpp
@@ -21,7 +21,7 @@ std::ostream& operator << ( std::ostream& os, const MeanRMSCalc & calc );
 class ErrorBarAnalysis {
 
 public:
-  ErrorBarAnalysis( TFile * outfile, PTF::Wrapper & ptf, PTF::PMTChannel & channel );
+  ErrorBarAnalysis( TFile * outfile, PTF::Wrapper & ptf, PTF::PMT & pmt );
   double get_errorbar( ) const { return hdiff->GetRMS(); }
 
 private:

--- a/include/PTFAnalysis.hpp
+++ b/include/PTFAnalysis.hpp
@@ -17,13 +17,13 @@
 
 using namespace std;
 
-/// This class takes a PTFWrapper reference, charge errorbar, and PMT channel as input
+/// This class takes a PTFWrapper reference, charge errorbar, and PMT as input
 /// It then does main analysis to fill a TTree of WaveformFitResults
 /// Has methods to later read back entries of the TTree
 /// Keeps track of number of Scan Points, and locations used find entries in TTree
 class PTFAnalysis {
 public:
-  PTFAnalysis( TFile * outfile, PTF::Wrapper & ptf, double errorbar, PTF::PMTChannel & channel, string config_file, bool savewf=false );
+  PTFAnalysis( TFile * outfile, PTF::Wrapper & ptf, double errorbar, PTF::PMT & pmt, string config_file, bool savewf=false );
   ~PTFAnalysis(){
     if ( fitresult ) delete fitresult;
   }

--- a/include/config.hpp
+++ b/include/config.hpp
@@ -6,6 +6,11 @@
 #define PHIDGET_FORMAT_X "phidg%i_Bx"
 #define PHIDGET_FORMAT_Y "phidg%i_By"
 #define PHIDGET_FORMAT_Z "phidg%i_Bz"
+#define GANTRY_FORMAT_X "gantry%i_x"
+#define GANTRY_FORMAT_Y "gantry%i_y"
+#define GANTRY_FORMAT_Z "gantry%i_z"
+#define GANTRY_FORMAT_THETA "gantry%i_rot"
+#define GANTRY_FORMAT_PHI "gantry%i_tilt"
 
 
 #endif

--- a/include/wrapper.hpp
+++ b/include/wrapper.hpp
@@ -56,7 +56,7 @@ enum PMTType {
   Hamamatsu_R3600_PMT = 0,
   PTF_Monitor_PMT = 1,
   PTF_Receiver_PMT = 2,
-  Hamamatsu_R12199_PMT = 3,
+  mPMT_REV0_PMT = 3,
   mPMT_Monitor_PMT = 4
 };
 

--- a/include/wrapper.hpp
+++ b/include/wrapper.hpp
@@ -56,7 +56,8 @@ enum PMTType {
   Hamamatsu_R3600_PMT = 0,
   PTF_Monitor_PMT = 1,
   PTF_Receiver_PMT = 2,
-  Hamamatsu_R12199_PMT = 3
+  Hamamatsu_R12199_PMT = 3,
+  mPMT_Monitor_PMT = 4
 };
 
 

--- a/include/wrapper.hpp
+++ b/include/wrapper.hpp
@@ -52,9 +52,18 @@ enum Gantry {
 };
 
 
-struct PMTChannel {
+enum PMTType {
+  Hamamatsu_R3600_PMT = 0,
+  PTF_Monitor_PMT = 1,
+  PTF_Receiver_PMT = 2,
+  Hamamatsu_R12199_PMT = 3
+};
+
+
+struct PMT {
   int pmt;
   int channel;
+  PMTType type;
 };
 
 
@@ -76,6 +85,7 @@ struct GantryData {
 
 struct PMTSet {
   int      channel;
+  PMTType  type;
   double*  data{nullptr};
   TBranch* branch{nullptr};
 
@@ -100,8 +110,8 @@ struct GantrySet {
 
 
 struct Wrapper {
-  Wrapper(unsigned long long maxSamples, unsigned long long sampleSize, const std::vector<PMTChannel>& activeChannels, const std::vector<int>& phidgets, const std::vector<Gantry>& gantries);
-  Wrapper(unsigned long long maxSamples, unsigned long long sampleSize, const std::vector<PMTChannel>& activeChannels, const std::vector<int>& phidgets, const std::vector<Gantry>& gantries, const std::string& fileName, const std::string& treeName = "scan_tree");
+  Wrapper(unsigned long long maxSamples, unsigned long long sampleSize, const std::vector<PMT>& activePMTs, const std::vector<int>& phidgets, const std::vector<Gantry>& gantries);
+  Wrapper(unsigned long long maxSamples, unsigned long long sampleSize, const std::vector<PMT>& activePMTs, const std::vector<int>& phidgets, const std::vector<Gantry>& gantries, const std::string& fileName, const std::string& treeName = "scan_tree");
   ~Wrapper();
 
 

--- a/include/wrapper.hpp
+++ b/include/wrapper.hpp
@@ -26,17 +26,18 @@
 ///                           pmt seems to be an arbitrary number of user 
 ///                           channel is the PMT channel in the data (digitizer channel)
 ///
-/// PTF::PhigetReading        Holds magnetic field readings (why 10 of them?)
+/// PTF::PhigetReading        Holds magnetic field readings
 ///
-/// PTF::Private::PMTSet      Is it private because its internally used?
-///                           Holds PMT data as pointer to array of doubles, and branch from input
+/// PTF::GantryData           Holds gantry data
 ///
-/// PTF::Private::PhigetSet   Holds one phiget location x,y,z,theta,phi
+/// PTF::PMTSet               Holds PMT data as pointer to array of doubles, and branch from input
+///
+/// PTF::PhigetSet            Holds one phidget reading, and branches from input
+///
+/// PTF::GantrySet            Holds one GantryData object, and branches from input
 ///
 /// PTF::Wrapper              Main helper class for accessing the PTF data
 ///                           See comments on public methods for help
-///
-/// Comments added by Blair
 
 // using namespace std;
 // using namespace boost;
@@ -46,8 +47,8 @@ namespace PTF {
 
 
 enum Gantry {
-  Gantry0,
-  Gantry1
+  Gantry0 = 0,
+  Gantry1 = 1
 };
 
 
@@ -64,24 +65,7 @@ struct PhidgetReading {
 };
 
 
-namespace Private {
-  struct PMTSet {
-    int      channel;
-    double*  data{nullptr};
-    TBranch* branch{nullptr};
-
-  };
-
-  struct PhidgetSet {
-    PhidgetReading data;
-    TBranch*       branchX{nullptr};
-    TBranch*       branchY{nullptr};
-    TBranch*       branchZ{nullptr};
-  };
-}
-
-
-struct GantryPos {
+struct GantryData {
   double x;
   double y;
   double z;
@@ -90,9 +74,34 @@ struct GantryPos {
 };
 
 
+struct PMTSet {
+  int      channel;
+  double*  data{nullptr};
+  TBranch* branch{nullptr};
+
+};
+
+struct PhidgetSet {
+  PhidgetReading data;
+  TBranch*       branchX{nullptr};
+  TBranch*       branchY{nullptr};
+  TBranch*       branchZ{nullptr};
+};
+
+struct GantrySet {
+  Gantry     gantry;
+  GantryData data;
+  TBranch*   branchX{nullptr};
+  TBranch*   branchY{nullptr};
+  TBranch*   branchZ{nullptr};
+  TBranch*   branchTheta{nullptr};
+  TBranch*   branchPhi{nullptr};
+};
+
+
 struct Wrapper {
-  Wrapper(unsigned long long maxSamples, unsigned long long sampleSize, const std::vector<PMTChannel>& activeChannels, const std::vector<int>& phidgets);
-  Wrapper(unsigned long long maxSamples, unsigned long long sampleSize, const std::vector<PMTChannel>& activeChannels, const std::vector<int>& phidgets, const std::string& fileName, const std::string& treeName = "scan_tree");
+  Wrapper(unsigned long long maxSamples, unsigned long long sampleSize, const std::vector<PMTChannel>& activeChannels, const std::vector<int>& phidgets, const std::vector<Gantry>& gantries);
+  Wrapper(unsigned long long maxSamples, unsigned long long sampleSize, const std::vector<PMTChannel>& activeChannels, const std::vector<int>& phidgets, const std::vector<Gantry>& gantries, const std::string& fileName, const std::string& treeName = "scan_tree");
   ~Wrapper();
 
 
@@ -130,7 +139,7 @@ public:
   // Returns the length of the samples
   int getSampleLength() const;
 
-  GantryPos getDataForCurrentEntry(Gantry whichGantry) const;
+  GantryData getDataForCurrentEntry(Gantry whichGantry) const;
 
   PhidgetReading getReadingForPhidget(int phidget) const;
 
@@ -142,11 +151,10 @@ private:
   unsigned long long entry{ULONG_MAX};
 
   // data
-  std::unordered_map<int, Private::PMTSet*>     pmtData;
-  std::unordered_map<int, Private::PhidgetSet*> phidgetData;
+  std::unordered_map<int, PMTSet*>     pmtData;
+  std::unordered_map<int, PhidgetSet*> phidgetData;
+  std::unordered_map<int, GantrySet*>  gantryData;
   
-  GantryPos g0;
-  GantryPos g1;
   unsigned long long    numEntries;
   unsigned long long    numSamples;
 
@@ -201,6 +209,11 @@ namespace Exceptions {
   class InvalidPMT : public std::runtime_error {
   public:
     InvalidPMT() : runtime_error("No such PMT.") {}
+  };
+
+  class InvalidGantry : public std::runtime_error {
+  public:
+    InvalidGantry() : runtime_error("No such gantry.") {}
   };
 
   class DataPointerError : public std::runtime_error {

--- a/mpmt_analysis.cpp
+++ b/mpmt_analysis.cpp
@@ -83,10 +83,11 @@ int main(int argc, char** argv) {
 
   // Set up PTF Wrapper
   vector<int> phidgets = {0, 1, 3};
-  PTF::PMTChannel Channel0 = {2,0}; // only looking at one channel at a time
-  PTF::PMTChannel Channel1 = {1,1}; // only looking at one channel at a time
-  vector<PTF::PMTChannel> activeChannels = { Channel0, Channel1 }; // must be ordered {main,monitor}
-  PTF::Wrapper wrapper = PTF::Wrapper(1, 1024, activeChannels, phidgets);
+  PTF::PMT PMT0 = {2,0,PTF::Hamamatsu_R12199_PMT}; // only looking at one pmt at a time
+  PTF::PMT PMT1 = {1,1,PTF::mPMT_Monitor_PMT}; // only looking at one pmt at a time
+  vector<PTF::PMT> activePMTs = { PMT0, PMT1 }; // must be ordered {main,monitor}
+  vector<PTF::Gantry> gantries = {PTF::Gantry0, PTF::Gantry1};
+  PTF::Wrapper wrapper = PTF::Wrapper(1, 1024, activePMTs, phidgets, gantries);
   std::cout << "Open file: " << std::endl;
   wrapper.openFile( string(argv[1]), "scan_tree");
   cerr << "Num entries: " << wrapper.getNumEntries() << endl << endl;
@@ -95,18 +96,18 @@ int main(int argc, char** argv) {
   // Commented out for the time being because it causes a seg fault once PTFAnalysis tries to fit the first waveform
   // Very strange behaviour!
   // Spent ages trying to work out what was going wrong but never got to the bottom of it
-  //ErrorBarAnalysis * errbars0 = new ErrorBarAnalysis( outFile, wrapper, Channel0 );
+  //ErrorBarAnalysis * errbars0 = new ErrorBarAnalysis( outFile, wrapper, PMT0 );
 
   //std::cout << "Using errorbar size " << errbars0->get_errorbar() << std::endl;
   
   // Do analysis of waveforms for each scanpoint
-  PTFAnalysis *analysis0 = new PTFAnalysis( outFile, wrapper, 4.4/*errbars0->get_errorbar()*/, Channel0, string(argv[3]), true );
+  PTFAnalysis *analysis0 = new PTFAnalysis( outFile, wrapper, 4.4/*errbars0->get_errorbar()*/, PMT0, string(argv[3]), true );
   analysis0->write_scanpoints();
 
-  // Switch channel to monitor PMT
+  // Switch PMT to monitor PMT
   
   // Do analysis of waveforms for each scanpoint
-  PTFAnalysis *analysis1 = new PTFAnalysis( outFile, wrapper, 4.4/*errbars1->get_errorbar()*/, Channel1, string(argv[3]), true );
+  PTFAnalysis *analysis1 = new PTFAnalysis( outFile, wrapper, 4.4/*errbars1->get_errorbar()*/, PMT1, string(argv[3]), true );
   
   // Do quantum efficiency analysis
   // This is now also done in a separate analysis script (including temperature corrections)

--- a/mpmt_analysis.cpp
+++ b/mpmt_analysis.cpp
@@ -83,7 +83,7 @@ int main(int argc, char** argv) {
 
   // Set up PTF Wrapper
   vector<int> phidgets = {0, 1, 3};
-  PTF::PMT PMT0 = {2,0,PTF::Hamamatsu_R12199_PMT}; // only looking at one pmt at a time
+  PTF::PMT PMT0 = {2,0,PTF::mPMT_REV0_PMT}; // only looking at one pmt at a time
   PTF::PMT PMT1 = {1,1,PTF::mPMT_Monitor_PMT}; // only looking at one pmt at a time
   vector<PTF::PMT> activePMTs = { PMT0, PMT1 }; // must be ordered {main,monitor}
   vector<PTF::Gantry> gantries = {PTF::Gantry0, PTF::Gantry1};

--- a/ptf_analysis.cpp
+++ b/ptf_analysis.cpp
@@ -84,7 +84,8 @@ int main(int argc, char** argv) {
   PTF::PMTChannel Channel0 = {0,0}; // only looking at one channel at a time
   PTF::PMTChannel Channel1 = {1,5}; // only looking at one channel at a time
   vector<PTF::PMTChannel> activeChannels = { Channel0, Channel1 }; // must be ordered {main,monitor}
-  PTF::Wrapper wrapper = PTF::Wrapper(6000, 70, activeChannels, phidgets);
+  vector<PTF::Gantry> gantries = {PTF::Gantry0, PTF::Gantry1};
+  PTF::Wrapper wrapper = PTF::Wrapper(6000, 70, activeChannels, phidgets, gantries);
   wrapper.openFile( string(argv[1]), "scan_tree");
   cerr << "Num entries: " << wrapper.getNumEntries() << endl << endl;
 

--- a/ptf_analysis.cpp
+++ b/ptf_analysis.cpp
@@ -81,11 +81,11 @@ int main(int argc, char** argv) {
 
   // Set up PTF Wrapper
   vector<int> phidgets = {0, 1, 3};
-  PTF::PMTChannel Channel0 = {0,0}; // only looking at one channel at a time
-  PTF::PMTChannel Channel1 = {1,5}; // only looking at one channel at a time
-  vector<PTF::PMTChannel> activeChannels = { Channel0, Channel1 }; // must be ordered {main,monitor}
+  PTF::PMT PMT0 = {0,0,PTF::Hamamatsu_R3600_PMT}; // only looking at one PMT at a time
+  PTF::PMT PMT1 = {1,5,PTF::PTF_Monitor_PMT}; // only looking at one PMT at a time
+  vector<PTF::PMT> activePMTs = { PMT0, PMT1 }; // must be ordered {main,monitor}
   vector<PTF::Gantry> gantries = {PTF::Gantry0, PTF::Gantry1};
-  PTF::Wrapper wrapper = PTF::Wrapper(6000, 70, activeChannels, phidgets, gantries);
+  PTF::Wrapper wrapper = PTF::Wrapper(6000, 70, activePMTs, phidgets, gantries);
   wrapper.openFile( string(argv[1]), "scan_tree");
   cerr << "Num entries: " << wrapper.getNumEntries() << endl << endl;
 
@@ -93,18 +93,18 @@ int main(int argc, char** argv) {
   // Commented out for the time being because it causes a seg fault once PTFAnalysis tries to fit the first waveform
   // Very strange behaviour!
   // Spent ages trying to work out what was going wrong but never got to the bottom of it
-  //ErrorBarAnalysis * errbars0 = new ErrorBarAnalysis( outFile, wrapper, Channel0 );
+  //ErrorBarAnalysis * errbars0 = new ErrorBarAnalysis( outFile, wrapper, PMT0 );
 
   //std::cout << "Using errorbar size " << errbars0->get_errorbar() << std::endl;
   
   // Do analysis of waveforms for each scanpoint
-  PTFAnalysis *analysis0 = new PTFAnalysis( outFile, wrapper, 4.4/*errbars0->get_errorbar()*/, Channel0, string(argv[3]), true );
+  PTFAnalysis *analysis0 = new PTFAnalysis( outFile, wrapper, 4.4/*errbars0->get_errorbar()*/, PMT0, string(argv[3]), true );
   analysis0->write_scanpoints();
 
-  // Switch channel to monitor PMT
+  // Switch PMT to monitor PMT
   
   // Do analysis of waveforms for each scanpoint
-  PTFAnalysis *analysis1 = new PTFAnalysis( outFile, wrapper, 4.4/*errbars1->get_errorbar()*/, Channel1, string(argv[3]), true );
+  PTFAnalysis *analysis1 = new PTFAnalysis( outFile, wrapper, 4.4/*errbars1->get_errorbar()*/, PMT1, string(argv[3]), true );
   
   // Do quantum efficiency analysis
   // This is now also done in a separate analysis script (including temperature corrections)

--- a/ptf_field_analysis.cpp
+++ b/ptf_field_analysis.cpp
@@ -43,7 +43,8 @@ int main(int argc, char** argv) {
   // Set up PTF Wrapper
   vector<int> phidgets = {4};
   vector<PTF::PMTChannel> activeChannels = {}; //Not looking at PMT data
-  PTF::Wrapper wrapper = PTF::Wrapper(6000, 70, activeChannels, phidgets);
+  vector<PTF::Gantry> gantries = {PTF::Gantry0, PTF::Gantry1};
+  PTF::Wrapper wrapper = PTF::Wrapper(6000, 70, activeChannels, phidgets, gantries);
   wrapper.openFile( string(argv[1])+"/out_run0"+argv[2]+".root", "scan_tree");
   cerr << "Num entries: " << wrapper.getNumEntries() << endl << endl;
 

--- a/ptf_field_analysis.cpp
+++ b/ptf_field_analysis.cpp
@@ -42,9 +42,9 @@ int main(int argc, char** argv) {
 
   // Set up PTF Wrapper
   vector<int> phidgets = {4};
-  vector<PTF::PMTChannel> activeChannels = {}; //Not looking at PMT data
+  vector<PTF::PMT> activePMTs = {}; //Not looking at PMT data
   vector<PTF::Gantry> gantries = {PTF::Gantry0, PTF::Gantry1};
-  PTF::Wrapper wrapper = PTF::Wrapper(6000, 70, activeChannels, phidgets, gantries);
+  PTF::Wrapper wrapper = PTF::Wrapper(6000, 70, activePMTs, phidgets, gantries);
   wrapper.openFile( string(argv[1])+"/out_run0"+argv[2]+".root", "scan_tree");
   cerr << "Num entries: " << wrapper.getNumEntries() << endl << endl;
 

--- a/src/ErrorBarAnalysis.cpp
+++ b/src/ErrorBarAnalysis.cpp
@@ -2,7 +2,7 @@
 
 using namespace std;
 
-ErrorBarAnalysis::ErrorBarAnalysis( TFile* outfile, PTF::Wrapper & wrapper, PTF::PMTChannel & channel ){
+ErrorBarAnalysis::ErrorBarAnalysis( TFile* outfile, PTF::Wrapper & wrapper, PTF::PMT & pmt ){
   static unsigned instance_count = 0;
   ++instance_count;
   
@@ -23,7 +23,7 @@ ErrorBarAnalysis::ErrorBarAnalysis( TFile* outfile, PTF::Wrapper & wrapper, PTF:
     // loop over the number of waveforms at this ScanPoint (index j) 
     for ( int j=0; j<numSamples; ++j ) {
       //if ( j>50 ) continue;
-      double* pmtsample=wrapper.getPmtSample( channel.pmt, j );
+      double* pmtsample=wrapper.getPmtSample( pmt.pmt, j );
       diffrmscalc.add( pmtsample[ 1 ] - pmtsample[ 0 ] );
       // only use first 20 time-bins of the waveform (time-bin index k)
       for ( int k = 0; k < std::min( 20, wrapper.getSampleLength() ); ++k ){
@@ -57,7 +57,7 @@ ErrorBarAnalysis::ErrorBarAnalysis( TFile* outfile, PTF::Wrapper & wrapper, PTF:
     // loop over the number of waveforms at this ScanPoint (index j) 
     for ( int j=0; j<numSamples; ++j) {
       //if ( j>50 ) continue;
-      double* pmtsample=wrapper.getPmtSample( channel.pmt, j );
+      double* pmtsample=wrapper.getPmtSample( pmt.pmt, j );
       hdiff->Fill( pmtsample[1] - pmtsample[ 0 ] );
       // only use first 20 time-bins of the waveform (time-bin index k)
       for ( int k = 0; k < std::min( 20, wrapper.getSampleLength() ); ++k ){

--- a/src/wrapper.cpp
+++ b/src/wrapper.cpp
@@ -5,15 +5,16 @@ using namespace std;
 using namespace PTF;
 
 
-Wrapper::Wrapper(unsigned long long maxSamples, unsigned long long sampleSize, const vector<PMTChannel>& activeChannels, const vector<int>& phidgets, const vector<Gantry>& gantries)
+Wrapper::Wrapper(unsigned long long maxSamples, unsigned long long sampleSize, const vector<PMT>& activePMTs, const vector<int>& phidgets, const vector<Gantry>& gantries)
   : maxSamples(maxSamples), sampleSize(sampleSize)
 {
-  for (auto chPair : activeChannels) {
+  for (auto pmt : activePMTs) {
     double* data = new double[maxSamples * sampleSize];
     PMTSet* pmtSet  = new PMTSet();
-    pmtSet->channel = chPair.channel;
+    pmtSet->channel = pmt.channel;
+    pmtSet->type = pmt.type;
     pmtSet->data    = data;
-    pmtData[chPair.pmt] = pmtSet;
+    pmtData[pmt.pmt] = pmtSet;
   }
   for (auto phidget : phidgets) {
     PhidgetSet* pSet = new PhidgetSet();
@@ -27,8 +28,8 @@ Wrapper::Wrapper(unsigned long long maxSamples, unsigned long long sampleSize, c
 }
 
 
-Wrapper::Wrapper(unsigned long long maxSamples, unsigned long long sampleSize, const vector<PMTChannel>& activeChannels, const vector<int>& phidgets, const vector<Gantry>& gantries, const string& fileName, const string& treeName)
-  : Wrapper(maxSamples, sampleSize, activeChannels, phidgets, gantries) {
+Wrapper::Wrapper(unsigned long long maxSamples, unsigned long long sampleSize, const vector<PMT>& activePMTs, const vector<int>& phidgets, const vector<Gantry>& gantries, const string& fileName, const string& treeName)
+  : Wrapper(maxSamples, sampleSize, activePMTs, phidgets, gantries) {
   openFile(fileName, treeName);
 }
 

--- a/src/wrapper.cpp
+++ b/src/wrapper.cpp
@@ -3,10 +3,9 @@
 
 using namespace std;
 using namespace PTF;
-using namespace Private;
 
 
-Wrapper::Wrapper(unsigned long long maxSamples, unsigned long long sampleSize, const vector<PMTChannel>& activeChannels, const vector<int>& phidgets)
+Wrapper::Wrapper(unsigned long long maxSamples, unsigned long long sampleSize, const vector<PMTChannel>& activeChannels, const vector<int>& phidgets, const vector<Gantry>& gantries)
   : maxSamples(maxSamples), sampleSize(sampleSize)
 {
   for (auto chPair : activeChannels) {
@@ -20,11 +19,16 @@ Wrapper::Wrapper(unsigned long long maxSamples, unsigned long long sampleSize, c
     PhidgetSet* pSet = new PhidgetSet();
     phidgetData[phidget] = pSet;
   }
+  for (auto gantry : gantries) {
+    GantrySet* gSet = new GantrySet();
+    gSet->gantry = gantry;
+    gantryData[gantry] = gSet;
+  }
 }
 
 
-Wrapper::Wrapper(unsigned long long maxSamples, unsigned long long sampleSize, const vector<PMTChannel>& activeChannels, const vector<int>& phidgets, const string& fileName, const string& treeName)
-  : Wrapper(maxSamples, sampleSize, activeChannels, phidgets) {
+Wrapper::Wrapper(unsigned long long maxSamples, unsigned long long sampleSize, const vector<PMTChannel>& activeChannels, const vector<int>& phidgets, const vector<Gantry>& gantries, const string& fileName, const string& treeName)
+  : Wrapper(maxSamples, sampleSize, activeChannels, phidgets, gantries) {
   openFile(fileName, treeName);
 }
 
@@ -41,6 +45,11 @@ Wrapper::~Wrapper() {
   for (auto phidget : phidgetData) {
     delete phidget.second;
   }
+
+  for (auto gantry : gantryData) {
+    delete gantry.second;
+  }
+
   if (tree) {
     unsetDataPointers();
     delete tree;
@@ -110,25 +119,43 @@ bool Wrapper::setDataPointers() {
     }
   }
 
-  TBranch
-    *g0X = tree->GetBranch("gantry0_x"), *g0Y = tree->GetBranch("gantry0_y"), *g0Z = tree->GetBranch("gantry0_z"),
-      *g0Theta = tree->GetBranch("gantry0_rot"), *g0Phi = tree->GetBranch("gantry0_tilt"),
-    *g1X = tree->GetBranch("gantry1_x"), *g1Y = tree->GetBranch("gantry1_y"), *g1Z = tree->GetBranch("gantry1_z"),
-      *g1Theta = tree->GetBranch("gantry1_rot"), *g1Phi = tree->GetBranch("gantry1_tilt"),
+  // Set gantry branches
+  for (auto gantry : gantryData) {
+    snprintf(branchName, 64, GANTRY_FORMAT_X, (int)gantry.second->gantry);
+    gantry.second->branchX = nullptr;
+    gantry.second->branchX = tree->GetBranch(branchName);
+    gantry.second->branchX->SetAddress(&gantry.second->data.x);
 
-    *brNumSamples = tree->GetBranch("num_points");
+    snprintf(branchName, 64, GANTRY_FORMAT_Y, (int)gantry.second->gantry);
+    gantry.second->branchY = nullptr;
+    gantry.second->branchY = tree->GetBranch(branchName);
+    gantry.second->branchY->SetAddress(&gantry.second->data.y);
 
-  g0X->SetAddress(&g0.x);
-  g0Y->SetAddress(&g0.y);
-  g0Z->SetAddress(&g0.z);
-  g0Theta->SetAddress(&g0.theta);
-  g0Phi->SetAddress(&g0.phi);
+    snprintf(branchName, 64, GANTRY_FORMAT_Z, (int)gantry.second->gantry);
+    gantry.second->branchZ = nullptr;
+    gantry.second->branchZ = tree->GetBranch(branchName);
+    gantry.second->branchZ->SetAddress(&gantry.second->data.z);
 
-  g1X->SetAddress(&g1.x);
-  g1Y->SetAddress(&g1.y);
-  g1Z->SetAddress(&g1.z);
-  g1Theta->SetAddress(&g1.theta);
-  g1Phi->SetAddress(&g1.phi);
+    snprintf(branchName, 64, GANTRY_FORMAT_THETA, (int)gantry.second->gantry);
+    gantry.second->branchTheta = nullptr;
+    gantry.second->branchTheta = tree->GetBranch(branchName);
+    gantry.second->branchTheta->SetAddress(&gantry.second->data.theta);
+
+    snprintf(branchName, 64, GANTRY_FORMAT_PHI, (int)gantry.second->gantry);
+    gantry.second->branchPhi = nullptr;
+    gantry.second->branchPhi = tree->GetBranch(branchName);
+    gantry.second->branchPhi->SetAddress(&gantry.second->data.phi);
+
+    if (gantry.second->branchX == nullptr
+        || gantry.second->branchY == nullptr
+        || gantry.second->branchZ == nullptr
+        || gantry.second->branchTheta == nullptr
+        || gantry.second->branchPhi == nullptr) {
+      return false;
+    }
+  }
+
+  TBranch* brNumSamples = tree->GetBranch("num_points");
 
   brNumSamples->SetAddress(&numSamples);
 
@@ -141,23 +168,21 @@ bool Wrapper::unsetDataPointers() {
     return false;
   
   for (auto pmt : pmtData) {
-    // if (pmt.second.branch)
-    //   delete pmt.second.branch;
     pmt.second->branch = nullptr;
   }
 
   for (auto phidget : phidgetData) {
-    // if (phidget.second.branchX)
-    //   delete phidget.second.branchX;
     phidget.second->branchX = nullptr;
-
-    // if (phidget.second.branchY)
-    //   delete phidget.second.branchY;
     phidget.second->branchY= nullptr;
-
-    // if (phidget.second.branchZ)
-    //   delete phidget.second.branchZ;
     phidget.second->branchZ = nullptr;
+  }
+
+  for (auto gantry : gantryData) {
+    gantry.second->branchX = nullptr;
+    gantry.second->branchY= nullptr;
+    gantry.second->branchZ = nullptr;
+    gantry.second->branchTheta = nullptr;
+    gantry.second->branchPhi = nullptr;
   }
 
   return true;
@@ -293,12 +318,17 @@ int Wrapper::getSampleLength() const {
 }
 
 
-GantryPos Wrapper::getDataForCurrentEntry(Gantry whichGantry) const {
+GantryData Wrapper::getDataForCurrentEntry(Gantry whichGantry) const {
   if (!isFileOpen()) {
     throw new Exceptions::NoFileIsOpen();
   }
-
-  return whichGantry == Gantry0 ? g0 : g1;
+  auto res = gantryData.find(whichGantry);
+  if (res == gantryData.end()) {
+    throw new Exceptions::InvalidGantry();
+  }
+  else {
+    return res->second->data;
+  }
 }
 
 

--- a/wrapper_demo.cpp
+++ b/wrapper_demo.cpp
@@ -7,9 +7,9 @@ using namespace std;
 
 
 int main(void) {
-  // decide which channels we'd like
-  vector<PTF::PMTChannel> channels = {
-    {1, 3} // this is saying we want pmt #1, which is on channel 3.
+  // decide which PMTs we'd like
+  vector<PTF::PMT> activePMTs = {
+    {0,0,PTF::Hamamatsu_R3600_PMT} // this is saying we want pmt #0, which is on channel 0 and is the SK PMT.
   };
 
   // decide which phidgets we'd like to read
@@ -20,9 +20,9 @@ int main(void) {
 
   // initialize the wrapper
   auto wrapper = PTF::Wrapper(
-    16384, // the maximum number of samples
-    34, // the size of one sample
-    channels,
+    6000, // the maximum number of samples
+    70, // the size of one sample
+    activePMTs,
     phidgets,
     gantries
   );

--- a/wrapper_demo.cpp
+++ b/wrapper_demo.cpp
@@ -15,12 +15,16 @@ int main(void) {
   // decide which phidgets we'd like to read
   vector<int> phidgets = {1, 3, 4};
 
+  // decide which gantries we'd like to include
+  vector<PTF::Gantry> gantries = {PTF::Gantry0, PTF::Gantry1};
+
   // initialize the wrapper
   auto wrapper = PTF::Wrapper(
     16384, // the maximum number of samples
     34, // the size of one sample
     channels,
-    phidgets
+    phidgets,
+    gantries
   );
 
   // now we can open our file
@@ -37,7 +41,7 @@ int main(void) {
     PhidgetReading phidgetReading = wrapper.getReadingForPhidget(3);
 
     // get data from gantry 1
-    GantryPos gantryData = wrapper.getDataForCurrentEntry(PTF::Gantry1);
+    GantryData gantryData = wrapper.getDataForCurrentEntry(PTF::Gantry1);
 
     // see how many samples there are for the current entry
     auto numSamples = wrapper.getNumSamples();


### PR DESCRIPTION
Closes #1 
Making inclusion of gantries optional. mPMT can now only have one gantry in MIDAS output file.
Adding new PMTType enum and including in PMT struct.