### PR TITLE
fix static counters in PTFAnalysis

### DIFF
--- a/src/PTFAnalysis.cpp
+++ b/src/PTFAnalysis.cpp
@@ -345,8 +345,8 @@ PTFAnalysis::PTFAnalysis( TFile* outfile, PTF::Wrapper & wrapper, double errorba
   }
 
   static int instance_count =0;
-  static int savewf_count =0;
-  static int savenowf_count = 0;
+  int savewf_count =0;
+  int savenowf_count = 0;
   ++instance_count;
   save_waveforms = savewf;
   


### PR DESCRIPTION
This commit makes savewf_counts and savenowf_counts non-static.

Having these integers be static meant that I wasn't saving waveforms for second and third channels that I was analyzing.  It isn't clear to me whether this was the intend of this code or just a side-effect.  If it was intended then I think it is better to add an option to PTFAnalysis that explicitly says that you don't want to save waveforms.