### PR TITLE
Fixing channel 1 bug about the threshold for pulse finding.

### DIFF
--- a/src/PulseFinding.cpp
+++ b/src/PulseFinding.cpp
@@ -38,7 +38,7 @@ void simple_threshold_technique(TH1D *hwaveform, WaveformFitResult *fitresult, P
 
   double threshold = baseline - 0.004;
     
-    if (pmt.channel == 1) threshold = baseline - 0.2;
+  //if (pmt.channel == 1) threshold = baseline - 0.2;
 
   int nsamples = hwaveform->GetNbinsX();
 


### PR DESCRIPTION
Commented out the line that increased the required height for pulse finding in channel 1 so that channel 1 pulses have the same requirement as all other channels.